### PR TITLE
Site next button loads next project

### DIFF
--- a/src/features/public/Donations/screens/MapboxMap.tsx
+++ b/src/features/public/Donations/screens/MapboxMap.tsx
@@ -390,8 +390,8 @@ export default function MapboxMap(props:mapProps) {
                 &nbsp;&nbsp;
               </p>
               <div
-                onClick={goToPrevProject}
-                onKeyPress={goToPrevProject}
+                onClick={goToNextProject}
+                onKeyPress={goToNextProject}
                 role="button"
                 tabIndex={0}
               >


### PR DESCRIPTION
To replicate the issue load any project on develop with sites, click on next project takes to previous instead of next
