### PR TITLE
I18n automatic detect of browser language

### DIFF
--- a/i18n/client.js
+++ b/i18n/client.js
@@ -6,14 +6,16 @@ export default new NextI18Next({
   use: [LanguageDetector, initReactI18next],
   defaultLanguage: 'en',
   fallbackLng: 'en',
+  debug: false,
   otherLanguages: ['de'], // list all languages here
   detection: {
-    // check if language is cached in cookies, if not check local storage
-    order: ['cookie', 'localStorage'],
+    // check if language is cached in cookies, if not check local storage, 
+    // last retrieve from browser language
+    order: ['cookie', 'localStorage', 'navigator'],
 
     // next-i18next by default searches for the 'next-i18next' cookie on server requests
-    lookupCookie: 'next-i18next',
-    lookupLocalStorage: 'i18nextLng',
+    lookupCookie: 'language',
+    lookupLocalStorage: 'language',
 
     // cache the language in cookies and local storage
     caches: ['cookie', 'localStorage'],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,8 +29,8 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
 }
 
 export default function PlanetWeb({ Component, pageProps, err }: any) {
-  const { Trans, useTranslation } = i18next;
-  const { i18n } = useTranslation();
+  // const { useTranslation } = i18next;
+  // const { i18n } = useTranslation();
 
   const tagManagerArgs = {
     gtmId: process.env.NEXT_PUBLIC_GA_TRACKING_ID,
@@ -72,16 +72,17 @@ export default function PlanetWeb({ Component, pageProps, err }: any) {
     loadConfig();
   }, []);
 
-  React.useEffect(() => {
-    if (localStorage.getItem('language') !== null) {
-      i18n.changeLanguage(localStorage.getItem('language'));
-    } else {
-      i18n.changeLanguage('en');
-    }
-  }, []);
+  // Norbert: language gets detected by i18next-browser-languagedetector
+  // React.useEffect(() => {
+  //   if (localStorage.getItem('language') !== null) {
+  //     i18n.changeLanguage(localStorage.getItem('language'));
+  //   } else {
+  //     i18n.changeLanguage('en');
+  //   }
+  // }, []);
 
   if (!initialized) {
-    return <p>Loading...</p>;
+    return <p></p>;
   } else {
     return (
       <ThemeProvider>

--- a/src/features/common/Footer/SelectLanguageAndCountry.tsx
+++ b/src/features/common/Footer/SelectLanguageAndCountry.tsx
@@ -16,7 +16,7 @@ import GreenRadio from '../InputTypes/GreenRadio';
 let styles = require('./SelectLanguageAndCountry.module.scss');
 import i18next from '../../../../i18n';
 
-const { Trans, useTranslation } = i18next;
+const { useTranslation } = i18next;
 
 export default function TransitionsModal(props) {
   const {
@@ -52,6 +52,7 @@ export default function TransitionsModal(props) {
   function handleOKClick() {
     window.localStorage.setItem('language', modalLanguage);
     setLanguage(modalLanguage);
+    i18n.changeLanguage(modalLanguage);
     window.localStorage.setItem('countryCode', selectedModalCountry);
     setSelectedCountry(selectedModalCountry);
     let currencyCode = getCountryDataBy('countryCode', selectedModalCountry)
@@ -66,7 +67,6 @@ export default function TransitionsModal(props) {
   // changes the language in local state whenever the language changes in Footer state
   useEffect(() => {
     if (language) {
-      i18n.changeLanguage(language);
       setModalLanguage(language);
     }
   }, [language]);

--- a/src/features/common/Footer/index.tsx
+++ b/src/features/common/Footer/index.tsx
@@ -55,14 +55,15 @@ export default function Footer() {
     let currencyCode;
     let countryCode;
 
-    if (
-      selectedCountry === 'DE' ||
-      selectedCountry === 'AT' ||
-      selectedCountry === 'CH'
-    ) {
-      setLanguage('de');
-      localStorage.setItem('language', 'de');
-    }
+    // Norbert: we do not want users in DACH force to use the website in German, do we?
+    // if (
+    //   selectedCountry === 'DE' ||
+    //   selectedCountry === 'AT' ||
+    //   selectedCountry === 'CH'
+    // ) {
+    //   setLanguage('de');
+    //   localStorage.setItem('language', 'de');
+    // }
 
     if (typeof Storage !== 'undefined') {
       if (localStorage.getItem('currencyCode')) {


### PR DESCRIPTION
- Make automatic browser language detection work by using same localStorage 'language' for i18n and our own app.
- Also removed 'Loading...' and instead show empty page.
- Do not force DACH users to use German language, do we?